### PR TITLE
use in_timezone parameter to make pytz and others work the same

### DIFF
--- a/src/icalendar/tests/conftest.py
+++ b/src/icalendar/tests/conftest.py
@@ -59,6 +59,10 @@ def events():
 def utc(request):
     return request.param
  
-@pytest.fixture(params=[pytz.timezone, tz.gettz, zoneinfo.ZoneInfo])
-def timezone(request):
+@pytest.fixture(params=[
+    lambda dt, tzname: pytz.timezone(tzname).localize(dt),
+    lambda dt, tzname: dt.replace(tzinfo=tz.gettz(tzname)),
+    lambda dt, tzname: dt.replace(tzinfo=zoneinfo.ZoneInfo(tzname))
+])
+def in_timezone(request):
     return request.param

--- a/src/icalendar/tests/test_encoding.py
+++ b/src/icalendar/tests/test_encoding.py
@@ -108,12 +108,12 @@ def test_events_unicoded(events, event_name):
     event = getattr(events, event_name)
     assert event.to_ical() == event.raw_ics
 
-def test_parses_event_with_non_ascii_tzid_issue_237(calendars, timezone):
+def test_parses_event_with_non_ascii_tzid_issue_237(calendars, in_timezone):
     """Issue #237 - Fail to parse timezone with non-ascii TZID
     see https://github.com/collective/icalendar/issues/237
     """
     start = calendars.issue_237_fail_to_parse_timezone_with_non_ascii_tzid.walk('VEVENT')[0].decoded('DTSTART')
-    expected = datetime.datetime(2017, 5, 11, 13, 30, tzinfo=timezone('America/Sao_Paulo'))
+    expected = in_timezone(datetime.datetime(2017, 5, 11, 13, 30), 'America/Sao_Paulo')
     assert start == expected
 
 def test_parses_timezone_with_non_ascii_tzid_issue_237(timezones):


### PR DESCRIPTION
see https://github.com/collective/icalendar/pull/418#issuecomment-1272123309